### PR TITLE
account for alphanumeric version numbers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests==2.22.0
 ckanapi==4.3
 # def requirements
 pytest==5.3.2
-black>=19
+black>=19.*
 deepdiff==4.0.9


### PR DESCRIPTION
`pip install -r requirements.txt` didn't work for me as it was. Changing the value below accounts for alphanumeric characters in the version number...currently 19.10b0 https://pypi.org/project/black/